### PR TITLE
Remove deprecated fields from Update Number snippet

### DIFF
--- a/numbers/update-number.sh
+++ b/numbers/update-number.sh
@@ -6,5 +6,5 @@ curl -X POST \
   "https://rest.nexmo.com/number/update?api_key=$NEXMO_API_KEY&api_secret=$NEXMO_API_SECRET" \
   -H "Content-Type: application/x-www-form-urlencoded" \
   -d "country=$COUNTRY_CODE&msisdn=$NEXMO_NUMBER&moHttpUrl=$SMS_CALLBACK_URL" \
-  -d "&messagesCallbackType=app&messagesCallbackValue=$MESSAGES_APPLICATION_ID" \
+  -d "&messagesCallbackType=app&messagesCallbackValue=$NEXMO_APPLICATION_ID" \
   -d "&voiceCallbackType=$VOICE_CALLBACK_TYPE&voiceCallbackValue=$VOICE_CALLBACK_VALUE&voiceStatusCallback=$VOICE_STATUS_URL"

--- a/numbers/update-number.sh
+++ b/numbers/update-number.sh
@@ -6,5 +6,5 @@ curl -X POST \
   "https://rest.nexmo.com/number/update?api_key=$NEXMO_API_KEY&api_secret=$NEXMO_API_SECRET" \
   -H "Content-Type: application/x-www-form-urlencoded" \
   -d "country=$COUNTRY_CODE&msisdn=$NEXMO_NUMBER&moHttpUrl=$SMS_CALLBACK_URL" \
-  -d "&messagesCallbackType=app&messagesCallbackValue=$NEXMO_APPLICATION_ID" \
+  -d "app_id=$NEXMO_APPLICATION_ID" \
   -d "&voiceCallbackType=$VOICE_CALLBACK_TYPE&voiceCallbackValue=$VOICE_CALLBACK_VALUE&voiceStatusCallback=$VOICE_STATUS_URL"


### PR DESCRIPTION
Update number snippet should use app_id instead of deprecated messagesCallback* params.

See: https://nexmoinc.atlassian.net/browse/DEVX-3431