### PR TITLE
Updating WhatsApp send MTM example in line with Messages v1 format

### DIFF
--- a/messages/whatsapp/send-mtm.sh
+++ b/messages/whatsapp/send-mtm.sh
@@ -7,35 +7,26 @@ curl -X POST $MESSAGES_API_URL \
   -H 'Authorization: Bearer' $JWT \
   -H 'Content-Type: application/json' \
   -d '{
-   "from":{
-      "type":"whatsapp",
-      "number":"'$WHATSAPP_NUMBER'"
+   "to": "$TO_NUMBER",
+   "from": "$WHATSAPP_NUMBER",
+   "channel": "whatsapp",
+   "message_type": "template",
+   "whatsapp": {
+     "policy": "deterministic",
+     "locale": "en-GB"
    },
-   "to":{
-      "type":"whatsapp",
-      "number":"'$TO_NUMBER'"
-   },
-   "message":{
-      "content":{
-         "type":"template",
-         "template":{
-            "name": "'$WHATSAPP_TEMPLATE_NAMESPACE':'$WHATSAPP_TEMPLATE_NAME'",
-            "parameters":[
-               {
-                  "default":"Vonage Verification"
-               },
-               {
-                  "default":"64873"
-               },
-               {
-                  "default":"10"
-               }
-            ]
+   "template":{
+      "name": "'$WHATSAPP_TEMPLATE_NAMESPACE':'$WHATSAPP_TEMPLATE_NAME'",
+      "parameters":[
+         {
+            "default":"Vonage Verification"
+         },
+         {
+            "default":"64873"
+         },
+         {
+            "default":"10"
          }
-      },
-      "whatsapp": {
-        "policy": "deterministic",
-      	"locale": "en-GB"
-      }
+      ]
    }
 }'


### PR DESCRIPTION
## Description

Updating code examples in line with v1.

A number of changes were made recently [in this PR](https://github.com/Vonage/vonage-curl-code-snippets/pull/99) to support Messages API v1 going live. This PR adds further changes to tidy up examples that were missed/ overlooked in those original changes