### PR TITLE
feat: Update RCS Snippets for Native types

### DIFF
--- a/jwt.sh
+++ b/jwt.sh
@@ -1,5 +1,5 @@
-# Do we have the Nexmo CLI installed?
-command -v vonage >/dev/null 2>&1 || { echo >&2 "The Nexmo CLI is not installed"; exit 1; }
+# Do we have the Vonage CLI installed?
+command -v vonage >/dev/null 2>&1 || { echo >&2 "The Vonage CLI is not installed"; exit 1; }
 
 # Can we load the private key?
 if [ ! -f "$VONAGE_PRIVATE_KEY" ]; then

--- a/messages/messenger/send-audio.sh
+++ b/messages/messenger/send-audio.sh
@@ -4,7 +4,7 @@ source "../../config.sh"
 source "../../jwt.sh"
 
 curl -X POST "${MESSAGES_API_URL}" \
-  -H "Authorization: Bearer ${JWT}"\
+  -H "Authorization: Bearer "$JWT\
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -d $'{

--- a/messages/messenger/send-file.sh
+++ b/messages/messenger/send-file.sh
@@ -4,7 +4,7 @@ source "../../config.sh"
 source "../../jwt.sh"
 
 curl -X POST "${MESSAGES_API_URL}" \
-  -H "Authorization: Bearer ${JWT}"\
+  -H "Authorization: Bearer "$JWT\
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -d $'{

--- a/messages/messenger/send-image.sh
+++ b/messages/messenger/send-image.sh
@@ -4,7 +4,7 @@ source "../../config.sh"
 source "../../jwt.sh"
 
 curl -X POST "${MESSAGES_API_URL}" \
-  -H "Authorization: Bearer ${JWT}"\
+  -H "Authorization: Bearer "$JWT\
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -d $'{

--- a/messages/messenger/send-text.sh
+++ b/messages/messenger/send-text.sh
@@ -4,7 +4,7 @@ source "../../config.sh"
 source "../../jwt.sh"
 
 curl -X POST "${MESSAGES_API_URL}" \
-  -H "Authorization: Bearer ${JWT}"\
+  -H "Authorization: Bearer "$JWT\
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -d $'{

--- a/messages/messenger/send-video.sh
+++ b/messages/messenger/send-video.sh
@@ -4,7 +4,7 @@ source "../../config.sh"
 source "../../jwt.sh"
 
 curl -X POST "${MESSAGES_API_URL}" \
-  -H "Authorization: Bearer ${JWT}"\
+  -H "Authorization: Bearer "$JWT\
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -d $'{

--- a/messages/mms/send-mms-audio.sh
+++ b/messages/mms/send-mms-audio.sh
@@ -4,7 +4,7 @@ source "../../config.sh"
 source "../../jwt.sh"
 
 curl -X POST "${MESSAGES_API_URL}" \
-  -H "Authorization: Bearer ${JWT}"\
+  -H "Authorization: Bearer "$JWT\
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -d $'{

--- a/messages/mms/send-mms-content.sh
+++ b/messages/mms/send-mms-content.sh
@@ -4,7 +4,7 @@ source "../../config.sh"
 source "../../jwt.sh"
 
 curl -X POST "${MESSAGES_API_URL}" \
-  -H "Authorization: Bearer ${JWT}"\
+  -H "Authorization: Bearer "$JWT\
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -d $'{

--- a/messages/mms/send-mms-file.sh
+++ b/messages/mms/send-mms-file.sh
@@ -4,7 +4,7 @@ source "../../config.sh"
 source "../../jwt.sh"
 
 curl -X POST "${MESSAGES_API_URL}" \
-  -H "Authorization: Bearer ${JWT}"\
+  -H "Authorization: Bearer "$JWT\
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -d $'{

--- a/messages/mms/send-mms-text.sh
+++ b/messages/mms/send-mms-text.sh
@@ -4,7 +4,7 @@ source "../../config.sh"
 source "../../jwt.sh"
 
 curl -X POST "${MESSAGES_API_URL}" \
-  -H "Authorization: Bearer ${JWT}"\
+  -H "Authorization: Bearer "$JWT\
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -d $'{

--- a/messages/mms/send-mms-vcard.sh
+++ b/messages/mms/send-mms-vcard.sh
@@ -4,7 +4,7 @@ source "../../config.sh"
 source "../../jwt.sh"
 
 curl -X POST "${MESSAGES_API_URL}" \
-  -H "Authorization: Bearer ${JWT}"\
+  -H "Authorization: Bearer "$JWT\
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -d $'{

--- a/messages/mms/send-mms-video.sh
+++ b/messages/mms/send-mms-video.sh
@@ -4,7 +4,7 @@ source "../../config.sh"
 source "../../jwt.sh"
 
 curl -X POST "${MESSAGES_API_URL}" \
-  -H "Authorization: Bearer ${JWT}"\
+  -H "Authorization: Bearer "$JWT\
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -d $'{

--- a/messages/mms/send-mms.sh
+++ b/messages/mms/send-mms.sh
@@ -4,7 +4,7 @@ source "../../config.sh"
 source "../../jwt.sh"
 
 curl -X POST "${MESSAGES_API_URL}" \
-  -H "Authorization: Bearer ${JWT}"\
+  -H "Authorization: Bearer "$JWT\
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -d $'{

--- a/messages/rcs/revoke-message.sh
+++ b/messages/rcs/revoke-message.sh
@@ -4,7 +4,7 @@ source "../../config.sh"
 source "../../jwt.sh"
 
 curl -X PATCH "${GEOSPECIFIC_MESSAGES_API_URL}/${MESSAGES_MESSAGE_ID}" \
-  -H "Authorization: Bearer ${JWT}"\
+  -H "Authorization: Bearer "$JWT\
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -d $'{"status": "revoked"}'

--- a/messages/rcs/send-file.sh
+++ b/messages/rcs/send-file.sh
@@ -4,7 +4,7 @@ source "../../config.sh"
 source "../../jwt.sh"
 
 curl -X POST "${MESSAGES_API_URL}" \
-  -H "Authorization: Bearer ${JWT}"\
+  -H "Authorization: Bearer "$JWT\
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -d $'{

--- a/messages/rcs/send-image.sh
+++ b/messages/rcs/send-image.sh
@@ -4,7 +4,7 @@ source "../../config.sh"
 source "../../jwt.sh"
 
 curl -X POST "${MESSAGES_API_URL}" \
-  -H "Authorization: Bearer ${JWT}"\
+  -H "Authorization: Bearer "$JWT\
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -d $'{

--- a/messages/rcs/send-rich-card-carousel.sh
+++ b/messages/rcs/send-rich-card-carousel.sh
@@ -4,61 +4,51 @@ source "../../config.sh"
 source "../../jwt.sh"
 
 curl -X POST "${MESSAGES_API_URL}" \
-  -H "Authorization: Bearer ${JWT}"\
+  -H "Authorization: Bearer "$JWT\
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -d $'{
     "to": "'${MESSAGES_TO_NUMBER}'",
     "from": "'${RCS_SENDER_ID}'",
     "channel": "rcs",
-    "message_type": "custom",
-    "custom": {
-      "contentMessage": {
-        "richCard": {
-          "carouselCard": {
-            "cardWidth": "MEDIUM",
-            "cardContents": [
-              {
-                "title": "Option 1: Photo",
-                "description": "Do you prefer this photo?",
-                "suggestions": [
-                  {
-                    "reply": {
-                      "text": "Option 1",
-                      "postbackData":"card_1"
-                    }
-                  }
-                ],
-                "media": {
-                  "height": "MEDIUM",
-                  "contentInfo": {
-                    "fileUrl": "'${MESSAGES_IMAGE_URL}'",
-                    "forceRefresh": "false"
-                  }
-                }
-              },
-              {
-                "title": "Option 2: Video",
-                "description": "Or this video?",
-                "suggestions": [
-                  {
-                    "reply": {
-                      "text": "Option 2",
-                      "postbackData": "card_2"
-                    }
-                  }
-                ],
-                "media": {
-                  "height": "MEDIUM",
-                  "contentInfo": {
-                    "fileUrl": "'${MESSAGES_VIDEO_URL}'",
-                    "forceRefresh": "false"
-                  }
-                }
-              }
-            ]
-          }
+    "message_type": "carousel",
+    "carousel": {
+      "cards": [
+        {
+          "title": "Option 1: Photo",
+          "text": "Do you prefer this photo?",
+          "media_url": "'${MESSAGES_IMAGE_URL}'",
+          "media_height": "SHORT",
+          "media_description": "Picture of a cat",
+          "thumbnail_url": "'${MESSAGES_IMAGE_URL}'",
+          "media_force_refresh": false,
+          "suggestions": [
+            {
+              "type": "reply",
+              "text": "Option 1",
+              "postback_data": "card_1"
+            }
+          ]
+        },
+        {
+          "title": "Option 2: Video",
+          "text": "Or this video?",
+          "media_url": "'${MESSAGES_VIDEO_URL}'",
+          "media_height": "SHORT",
+          "media_description": "Video of a cat",
+          "thumbnail_url": "'${MESSAGES_IMAGE_URL}'",
+          "media_force_refresh": false,
+          "suggestions": [
+            {
+              "type": "reply",
+              "text": "Option 2",
+              "postback_data": "card_2"
+            }
+          ]
         }
-      }
+      ]
+    },
+    "rcs": {
+      "card_width": "SMALL"
     }
   }'

--- a/messages/rcs/send-rich-card-standalone.sh
+++ b/messages/rcs/send-rich-card-standalone.sh
@@ -4,47 +4,37 @@ source "../../config.sh"
 source "../../jwt.sh"
 
 curl -X POST "${MESSAGES_API_URL}" \
-  -H "Authorization: Bearer ${JWT}"\
+  -H "Authorization: Bearer "$JWT\
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -d $'{
     "to": "'${MESSAGES_TO_NUMBER}'",
     "from": "'${RCS_SENDER_ID}'",
     "channel": "rcs",
-    "message_type": "custom",
-    "custom": {
-      "contentMessage": {
-        "richCard": {
-          "standaloneCard": {
-            "thumbnailImageAlignment": "RIGHT",
-            "cardOrientation": "VERTICAL",
-            "cardContent": {
-              "title": "Quick question",
-              "description": "Do you like this picture?",
-              "media": {
-                "height": "TALL",
-                "contentInfo": {
-                  "fileUrl": "'${MESSAGES_IMAGE_URL}'",
-                  "forceRefresh": "false"
-                }
-              },
-              "suggestions": [
-                {
-                  "reply": {
-                    "text": "Yes",
-                    "postbackData": "suggestion_1"
-                  }
-                },
-                {
-                  "reply": {
-                    "text": "I love it!",
-                    "postbackData": "suggestion_2"
-                  }
-                }
-              ]
-            }
-          }
+    "message_type": "card",
+    "card": {
+      "title": "Quick question",
+      "text": "Do you like this picture?",
+      "media_url": "'${MESSAGES_IMAGE_URL}'",
+      "media_height": "SHORT",
+      "media_description": "Picture of a cat",
+      "thumbnail_url": "'${MESSAGES_IMAGE_URL}'",
+      "media_force_refresh": false,
+      "suggestions": [
+        {
+          "type": "reply",
+          "text": "Yes",
+          "postback_data": "suggestion_1"
+        },
+        {
+          "type": "reply",
+          "text": "I love it!",
+          "postback_data": "suggestion_2"
         }
-      }
+      ]
+    },
+    "rcs": {
+      "card_orientation": "HORIZONTAL",
+      "image_alignment": "RIGHT"
     }
   }'

--- a/messages/rcs/send-suggested-action-create-calendar-event.sh
+++ b/messages/rcs/send-suggested-action-create-calendar-event.sh
@@ -4,32 +4,25 @@ source "../../config.sh"
 source "../../jwt.sh"
 
 curl -X POST "${MESSAGES_API_URL}" \
-  -H "Authorization: Bearer ${JWT}"\
+  -H "Authorization: Bearer "$JWT\
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -d $'{
     "to": "'${MESSAGES_TO_NUMBER}'",
     "from": "'${RCS_SENDER_ID}'",
     "channel": "rcs",
-    "message_type": "custom",
-    "custom": {
-      "contentMessage": {
-        "text": "Product Launch: Save the date!",
-        "suggestions": [
-          {
-            "action": {
-              "text": "Save to calendar",
-              "postbackData": "postback_data_1234",
-              "fallbackUrl": "https://www.google.com/calendar",
-              "createCalendarEventAction": {
-                "startTime": "2024-06-28T19:00:00Z",
-                "endTime": "2024-06-28T20:00:00Z",
-                "title": "Vonage API Product Launch",
-                "description": "Event to demo a new and exciting Vonage API product"
-              }
-            }
-          }
-        ]
+    "message_type": "text",
+    "text": "Product Launch: Save the date!",
+    "suggestions": [
+      {
+        "type": "create_calendar_event",
+        "text": "Save to calendar",
+        "postback_data": "postback_data_1234",
+        "start_time": "2024-06-28T19:00:00Z",
+        "end_time": "2024-06-28T20:00:00Z",
+        "title": "Vonage API Product Launch",
+        "description": "Event to demo new and exciting Vonage API product",
+        "fallback_url": "https://www.google.com/calendar"
       }
-    }
+    ]
   }'

--- a/messages/rcs/send-suggested-action-dial.sh
+++ b/messages/rcs/send-suggested-action-dial.sh
@@ -4,29 +4,22 @@ source "../../config.sh"
 source "../../jwt.sh"
 
 curl -X POST "${MESSAGES_API_URL}" \
-  -H "Authorization: Bearer ${JWT}"\
+  -H "Authorization: Bearer "$JWT\
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -d $'{
     "to": "'${MESSAGES_TO_NUMBER}'",
     "from": "'${RCS_SENDER_ID}'",
     "channel": "rcs",
-    "message_type": "custom",
-    "custom": {
-      "contentMessage": {
-        "text": "Call us to claim your free gift!",
-        "suggestions": [
-          {
-            "action": {
-              "text": "Call now!",
-              "postbackData": "postback_data_1234",
-              "fallbackUrl": "https://www.example.com/contact/",
-              "dialAction": {
-                "phoneNumber": "+447900000000"
-              }
-            }
-          }
-        ]
+    "message_type": "text",
+    "text": "Call us to claim your free gift!",
+    "suggestions": [
+      {
+        "type": "dial",
+        "text": "Call now!",
+        "postback_data": "postback_data_1234",
+        "phone_number": "+447900000000",
+        "fallback_url": "https://www.example.com/contact/"
       }
-    }
+    ]
   }'

--- a/messages/rcs/send-suggested-action-multiple.sh
+++ b/messages/rcs/send-suggested-action-multiple.sh
@@ -4,38 +4,29 @@ source "../../config.sh"
 source "../../jwt.sh"
 
 curl -X POST "${MESSAGES_API_URL}" \
-  -H "Authorization: Bearer ${JWT}"\
+  -H "Authorization: Bearer "$JWT\
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -d $'{
     "to": "'${MESSAGES_TO_NUMBER}'",
     "from": "'${RCS_SENDER_ID}'",
     "channel": "rcs",
-    "message_type": "custom",
-    "custom": {
-      "contentMessage": {
-        "text": "Need some help? Call us now or visit our website for more information.",
-        "suggestions": [
-          {
-            "action": {
-              "text": "Call us",
-              "postbackData": "postback_data_1234",
-              "fallbackUrl": "https://www.example.com/contact/",
-              "dialAction": {
-                "phoneNumber": "+447900000000"
-              }
-            }
-          },
-          {
-            "action": {
-              "text": "Visit site",
-              "postbackData": "postback_data_1234",
-              "openUrlAction": {
-                "url": "http://example.com/"
-              }
-            }
-          }
-        ]
+    "message_type": "text",
+    "text": "Need some help? Call us now or visit our website for more information.",
+    "suggestions": [
+      {
+        "type": "dial",
+        "text": "Call us",
+        "postback_data": "postback_data_1234",
+        "phone_number": "+447900000000",
+        "fallback_url": "https://www.example.com/contact/"
+      },
+      {
+        "type": "open_url",
+        "text": "Visit site",
+        "postback_data": "postback_data_1234",
+        "url": "http://example.com/",
+        "description": "A URL for the Example website"
       }
-    }
+    ]
   }'

--- a/messages/rcs/send-suggested-action-open-url-webview.sh
+++ b/messages/rcs/send-suggested-action-open-url-webview.sh
@@ -15,11 +15,12 @@ curl -X POST "${MESSAGES_API_URL}" \
     "text": "Check out our latest offers!",
     "suggestions": [
       {
-        "type": "open_url",
+        "type": "open_url_in_webview",
         "text": "Open product page",
         "postback_data": "postback_data_1234",
         "url": "http://example.com/",
-        "description": "A URL for the Example website"
+        "description": "A URL for the Example website",
+        "view_mode": "FULL"
       }
     ]
   }'

--- a/messages/rcs/send-suggested-action-share-location.sh
+++ b/messages/rcs/send-suggested-action-share-location.sh
@@ -4,26 +4,20 @@ source "../../config.sh"
 source "../../jwt.sh"
 
 curl -X POST "${MESSAGES_API_URL}" \
-  -H "Authorization: Bearer ${JWT}"\
+  -H "Authorization: Bearer "$JWT\
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -d $'{
     "to": "'${MESSAGES_TO_NUMBER}'",
     "from": "'${RCS_SENDER_ID}'",
     "channel": "rcs",
-    "message_type": "custom",
-    "custom": {
-      "contentMessage": {
-        "text": "Your driver will come and meet you at your specified location.",
-        "suggestions": [
-          {
-            "action": {
-              "text": "Share a location",
-              "postbackData": "postback_data_1234",
-              "shareLocationAction": {}
-            }
-          }
-        ]
+    "message_type": "text",
+    "text": "Your driver will come and meet you at your specified location.",
+    "suggestions": [
+      {
+        "type": "share_location",
+        "text": "Share a location",
+        "postback_data": "postback_data_1234"
       }
-    }
+    ]
   }'

--- a/messages/rcs/send-suggested-action-view-location.sh
+++ b/messages/rcs/send-suggested-action-view-location.sh
@@ -4,33 +4,24 @@ source "../../config.sh"
 source "../../jwt.sh"
 
 curl -X POST "${MESSAGES_API_URL}" \
-  -H "Authorization: Bearer ${JWT}"\
+  -H "Authorization: Bearer "$JWT\
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -d $'{
     "to": "'${MESSAGES_TO_NUMBER}'",
     "from": "'${RCS_SENDER_ID}'",
     "channel": "rcs",
-    "message_type": "custom",
-    "custom": {
-      "contentMessage": {
-        "text": "Drop by our office!",
-        "suggestions": [
-          {
-            "action": {
-              "text": "View map",
-              "postbackData": "postback_data_1234",
-              "fallbackUrl": "https://www.google.com/maps/place/Vonage/@51.5230371,-0.0852492,15z",
-              "viewLocationAction": {
-                "latLong": {
-                  "latitude": "51.5230371",
-                  "longitude": "-0.0852492"
-                },
-                "label": "Vonage London Office"
-              }
-            }
-          }
-        ]
+   "message_type": "text",
+    "text": "Drop by our office!",
+    "suggestions": [
+      {
+        "type": "view_location",
+        "text": "View map",
+        "postback_data": "postback_data_1234",
+        "latitude": "51.5230371",
+        "longitude": "-0.0852492",
+        "pin_label": "Vonage London Office",
+        "fallback_url": "https://www.google.com/maps/place/Vonage/@51.5230371,-0.0852492,15z"
       }
-    }
+    ]
   }'

--- a/messages/rcs/send-suggested-reply.sh
+++ b/messages/rcs/send-suggested-reply.sh
@@ -4,31 +4,25 @@ source "../../config.sh"
 source "../../jwt.sh"
 
 curl -X POST "${MESSAGES_API_URL}" \
-  -H "Authorization: Bearer ${JWT}"\
+  -H "Authorization: Bearer "$JWT\
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -d $'{
     "to": "'${MESSAGES_TO_NUMBER}'",
     "from": "'${RCS_SENDER_ID}'",
     "channel": "rcs",
-    "message_type": "custom",
-    "custom": {
-      "contentMessage": {
-        "text": "What do you think of Vonage APIs?",
-        "suggestions": [
-          {
-            "reply": {
-              "text": "Great!",
-              "postbackData": "suggestion_1"
-            }
-          },
-          {
-            "reply": {
-              "text": "Awesome!",
-              "postbackData": "suggestion_2"
-            }
-          }
-        ]
+    "message_type": "text",
+    "text": "What do you think of Vonage APIs?",
+    "suggestions": [
+      {
+        "type": "reply",
+        "text": "Great!",
+        "postback_data": "suggestion_1"
+      },
+      {
+        "type": "reply",
+        "text": "Awesome!",
+        "postback_data": "suggestion_2"
       }
-    }
+    ]
   }'

--- a/messages/rcs/send-text.sh
+++ b/messages/rcs/send-text.sh
@@ -4,7 +4,7 @@ source "../../config.sh"
 source "../../jwt.sh"
 
 curl -X POST "${MESSAGES_API_URL}" \
-  -H "Authorization: Bearer ${JWT}"\
+  -H "Authorization: Bearer "$JWT\
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -d $'{

--- a/messages/rcs/send-video.sh
+++ b/messages/rcs/send-video.sh
@@ -4,7 +4,7 @@ source "../../config.sh"
 source "../../jwt.sh"
 
 curl -X POST "${MESSAGES_API_URL}" \
-  -H "Authorization: Bearer ${JWT}"\
+  -H "Authorization: Bearer "$JWT\
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -d $'{

--- a/messages/sandbox/messenger/send-text.sh
+++ b/messages/sandbox/messenger/send-text.sh
@@ -4,7 +4,7 @@ source "../../../config.sh"
 source "../../../jwt.sh"
 
 curl -X POST $MESSAGES_SANDBOX_URL \
-  -H "Authorization: Bearer ${JWT}"\
+  -H "Authorization: Bearer "$JWT\
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -d $'{

--- a/messages/sandbox/viber/send-text.sh
+++ b/messages/sandbox/viber/send-text.sh
@@ -4,7 +4,7 @@ source "../../../config.sh"
 source "../../../jwt.sh"
 
 curl -X POST $MESSAGES_SANDBOX_URL \
-  -H "Authorization: Bearer ${JWT}"\
+  -H "Authorization: Bearer "$JWT\
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -d $'{

--- a/messages/sandbox/whatsapp/send-text.sh
+++ b/messages/sandbox/whatsapp/send-text.sh
@@ -4,7 +4,7 @@ source "../../../config.sh"
 source "../../../jwt.sh"
 
 curl -X POST $MESSAGES_SANDBOX_URL \
-  -H "Authorization: Bearer ${JWT}"\
+  -H "Authorization: Bearer "$JWT\
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -d $'{

--- a/messages/send-message-with-failover.sh
+++ b/messages/send-message-with-failover.sh
@@ -4,7 +4,7 @@ source "../config.sh"
 source "../jwt.sh"
 
 curl -X POST "${MESSAGES_API_URL}" \
-  -H "Authorization: Bearer ${JWT}"\
+  -H "Authorization: Bearer "$JWT\
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -d $'{

--- a/messages/sms/send-sms.sh
+++ b/messages/sms/send-sms.sh
@@ -4,7 +4,7 @@ source "../../config.sh"
 source "../../jwt.sh"
 
 curl -X POST https://api.nexmo.com/v1/messages \
-  -H "Authorization: Bearer ${JWT}"\
+  -H "Authorization: Bearer "$JWT\
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -d $'{

--- a/messages/viber/send-file.sh
+++ b/messages/viber/send-file.sh
@@ -4,7 +4,7 @@ source "../../config.sh"
 source "../../jwt.sh"
 
 curl -X POST "${MESSAGES_API_URL}" \
-  -H "Authorization: Bearer ${JWT}"\
+  -H "Authorization: Bearer "$JWT\
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -d $'{

--- a/messages/viber/send-image.sh
+++ b/messages/viber/send-image.sh
@@ -4,7 +4,7 @@ source "../../config.sh"
 source "../../jwt.sh"
 
 curl -X POST "${MESSAGES_API_URL}" \
-  -H "Authorization: Bearer ${JWT}"\
+  -H "Authorization: Bearer "$JWT\
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -d $'{

--- a/messages/viber/send-text.sh
+++ b/messages/viber/send-text.sh
@@ -4,7 +4,7 @@ source "../../config.sh"
 source "../../jwt.sh"
 
 curl -X POST "${MESSAGES_API_URL}" \
-  -H "Authorization: Bearer ${JWT}"\
+  -H "Authorization: Bearer "$JWT\
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -d $'{

--- a/messages/viber/send-video.sh
+++ b/messages/viber/send-video.sh
@@ -4,7 +4,7 @@ source "../../config.sh"
 source "../../jwt.sh"
 
 curl -X POST "${MESSAGES_API_URL}" \
-  -H "Authorization: Bearer ${JWT}"\
+  -H "Authorization: Bearer "$JWT\
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -d $'{

--- a/messages/whatsapp/mark-as-read.sh
+++ b/messages/whatsapp/mark-as-read.sh
@@ -4,7 +4,7 @@ source "../../config.sh"
 source "../../jwt.sh"
 
 curl -X PATCH "${GEOSPECIFIC_MESSAGES_API_URL}/${MESSAGES_MESSAGE_ID}" \
-  -H "Authorization: Bearer ${JWT}"\
+  -H "Authorization: Bearer "$JWT\
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -d $'{"status": "read"}'

--- a/messages/whatsapp/send-audio.sh
+++ b/messages/whatsapp/send-audio.sh
@@ -4,7 +4,7 @@ source "../../config.sh"
 source "../../jwt.sh"
 
 curl -X POST "${MESSAGES_API_URL}" \
-  -H "Authorization: Bearer ${JWT}"\
+  -H "Authorization: Bearer "$JWT\
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -d $'{

--- a/messages/whatsapp/send-authentication-template.sh
+++ b/messages/whatsapp/send-authentication-template.sh
@@ -4,7 +4,7 @@ source "../../config.sh"
 source "../../jwt.sh"
 
 curl -X POST "${MESSAGES_API_URL}" \
-  -H "Authorization: Bearer ${JWT}"\
+  -H "Authorization: Bearer "$JWT\
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -d $'{

--- a/messages/whatsapp/send-button-link.sh
+++ b/messages/whatsapp/send-button-link.sh
@@ -4,7 +4,7 @@ source "../../config.sh"
 source "../../jwt.sh"
 
 curl -X POST "${MESSAGES_API_URL}" \
-  -H "Authorization: Bearer ${JWT}"\
+  -H "Authorization: Bearer "$JWT\
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -d $'{

--- a/messages/whatsapp/send-button-quick-reply.sh
+++ b/messages/whatsapp/send-button-quick-reply.sh
@@ -4,7 +4,7 @@ source "../../config.sh"
 source "../../jwt.sh"
 
 curl -X POST "${MESSAGES_API_URL}" \
-  -H "Authorization: Bearer ${JWT}"\
+  -H "Authorization: Bearer "$JWT\
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -d $'{

--- a/messages/whatsapp/send-contact.sh
+++ b/messages/whatsapp/send-contact.sh
@@ -4,7 +4,7 @@ source "../../config.sh"
 source "../../jwt.sh"
 
 curl -X POST "${MESSAGES_API_URL}" \
-  -H "Authorization: Bearer ${JWT}"\
+  -H "Authorization: Bearer "$JWT\
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -d $'{

--- a/messages/whatsapp/send-file.sh
+++ b/messages/whatsapp/send-file.sh
@@ -4,7 +4,7 @@ source "../../config.sh"
 source "../../jwt.sh"
 
 curl -X POST "${MESSAGES_API_URL}" \
-  -H "Authorization: Bearer ${JWT}"\
+  -H "Authorization: Bearer "$JWT\
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -d $'{

--- a/messages/whatsapp/send-image.sh
+++ b/messages/whatsapp/send-image.sh
@@ -4,7 +4,7 @@ source "../../config.sh"
 source "../../jwt.sh"
 
 curl -X POST "${MESSAGES_API_URL}" \
-  -H "Authorization: Bearer ${JWT}"\
+  -H "Authorization: Bearer "$JWT\
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -d $'{

--- a/messages/whatsapp/send-location.sh
+++ b/messages/whatsapp/send-location.sh
@@ -4,7 +4,7 @@ source "../../config.sh"
 source "../../jwt.sh"
 
 curl -X POST "${MESSAGES_API_URL}" \
-  -H "Authorization: Bearer ${JWT}"\
+  -H "Authorization: Bearer "$JWT\
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -d $'{

--- a/messages/whatsapp/send-media-mtm.sh
+++ b/messages/whatsapp/send-media-mtm.sh
@@ -4,7 +4,7 @@ source "../../config.sh"
 source "../../jwt.sh"
 
 curl -X POST "${MESSAGES_API_URL}" \
-  -H "Authorization: Bearer ${JWT}"\
+  -H "Authorization: Bearer "$JWT\
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -d $'{

--- a/messages/whatsapp/send-mtm.sh
+++ b/messages/whatsapp/send-mtm.sh
@@ -4,7 +4,7 @@ source "../../config.sh"
 source "../../jwt.sh"
 
 curl -X POST "${MESSAGES_API_URL}" \
-  -H "Authorization: Bearer ${JWT}"\
+  -H "Authorization: Bearer "$JWT\
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -d $'{

--- a/messages/whatsapp/send-multi-product.sh
+++ b/messages/whatsapp/send-multi-product.sh
@@ -4,7 +4,7 @@ source "../../config.sh"
 source "../../jwt.sh"
 
 curl -X POST "${MESSAGES_API_URL}" \
-  -H "Authorization: Bearer ${JWT}"\
+  -H "Authorization: Bearer "$JWT\
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -d $'{

--- a/messages/whatsapp/send-reaction.sh
+++ b/messages/whatsapp/send-reaction.sh
@@ -4,7 +4,7 @@ source "../../config.sh"
 source "../../jwt.sh"
 
 curl -X POST "${MESSAGES_API_URL}" \
-  -H "Authorization: Bearer ${JWT}"\
+  -H "Authorization: Bearer "$JWT\
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -d $'{

--- a/messages/whatsapp/send-single-product.sh
+++ b/messages/whatsapp/send-single-product.sh
@@ -4,7 +4,7 @@ source "../../config.sh"
 source "../../jwt.sh"
 
 curl -X POST "${MESSAGES_API_URL}" \
-  -H "Authorization: Bearer ${JWT}"\
+  -H "Authorization: Bearer "$JWT\
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -d $'{

--- a/messages/whatsapp/send-sticker-id.sh
+++ b/messages/whatsapp/send-sticker-id.sh
@@ -4,7 +4,7 @@ source "../../config.sh"
 source "../../jwt.sh"
 
 curl -X POST "${MESSAGES_API_URL}" \
-  -H "Authorization: Bearer ${JWT}"\
+  -H "Authorization: Bearer "$JWT\
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -d $'{

--- a/messages/whatsapp/send-sticker-url.sh
+++ b/messages/whatsapp/send-sticker-url.sh
@@ -4,7 +4,7 @@ source "../../config.sh"
 source "../../jwt.sh"
 
 curl -X POST "${MESSAGES_API_URL}" \
-  -H "Authorization: Bearer ${JWT}"\
+  -H "Authorization: Bearer "$JWT\
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -d $'{

--- a/messages/whatsapp/send-text.sh
+++ b/messages/whatsapp/send-text.sh
@@ -4,7 +4,7 @@ source "../../config.sh"
 source "../../jwt.sh"
 
 curl -X POST "${MESSAGES_API_URL}" \
-  -H "Authorization: Bearer ${JWT}"\
+  -H "Authorization: Bearer "$JWT\
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -d $'{

--- a/messages/whatsapp/send-unreaction.sh
+++ b/messages/whatsapp/send-unreaction.sh
@@ -4,7 +4,7 @@ source "../../config.sh"
 source "../../jwt.sh"
 
 curl -X POST "${MESSAGES_API_URL}" \
-  -H "Authorization: Bearer ${JWT}"\
+  -H "Authorization: Bearer "$JWT\
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -d $'{

--- a/messages/whatsapp/send-video.sh
+++ b/messages/whatsapp/send-video.sh
@@ -4,7 +4,7 @@ source "../../config.sh"
 source "../../jwt.sh"
 
 curl -X POST "${MESSAGES_API_URL}" \
-  -H "Authorization: Bearer ${JWT}"\
+  -H "Authorization: Bearer "$JWT\
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -d $'{


### PR DESCRIPTION
This PR:

- Updates the RCS code snippets to use the native types for suggestions, cards, and carousels instead of the `custom` type
- Updates the way that the `JWT` variable is passed to the `-H` flag, due to the previous way causing issues with some versions of libcurl.